### PR TITLE
Trim _first_ wireless interface

### DIFF
--- a/wireless
+++ b/wireless
@@ -7,7 +7,7 @@ FORMAT_QUALITY="${format_quality:-%3d%s}"
 
 if [ "$INTERFACE" = "_first_" ]
 then
-  INTERFACE="$(cat /proc/net/wireless | sed -n 3p | cut -d: -f1)"
+  INTERFACE="$(cat /proc/net/wireless | sed -n 3p | cut -d: -f1 | sed -e 's/^[[:space:]]*//')"
 fi
 
 bitrate () {


### PR DESCRIPTION
On my system, Fedora 31, I am getting the `_first_` interface as `  wlo1` instead of the expected `wlo1`. This should do nothing on any system that was working and fix systems like mine.